### PR TITLE
switch to xdg-download/JDownloder as download folder...

### DIFF
--- a/jd-wrapper.sh
+++ b/jd-wrapper.sh
@@ -3,6 +3,7 @@
 JDDIR=$XDG_DATA_HOME/jdownloader
 JDSETUP=$XDG_CACHE_HOME/JD2Setup.sh
 JDDWNLDFLDR="$(xdg-user-dir DOWNLOAD)/JDownloader"
+JDGENSETJSON="${XDG_DATA_HOME}/jdownloader/cfg/org.jdownloader.settings.GeneralSettings.json"
 
 if [ ! -f $JDDIR/JDownloader.jar ]; then
     install -Dm755 /app/extra/JD2Setup.sh $JDSETUP
@@ -10,6 +11,12 @@ if [ ! -f $JDDIR/JDownloader.jar ]; then
     mv $JDDIR/tmp/JDownloader.jar $JDDIR
     rm -rf $JDSETUP $JDDIR/tmp
     zenity --info --text "Download directory: ${JDDWNLDFLDR}" --no-wrap --title "JDownloader"
+fi
+
+## Change wrong path ~/Downloads to the new one. 
+if [ -f ${JDGENSETJSON} ]; then
+    sed -i s+\"$(xdg-user-dir DOWNLOAD)\"+\"${JDDWNLDFLDR}\"+g "${JDGENSETJSON}"
+    sed -i s+\"/home/${USER}/Downloads\"+\"${JDDWNLDFLDR}\"+g "${JDGENSETJSON}"
 fi
 
 java -jar $JDDIR/JDownloader.jar

--- a/jd-wrapper.sh
+++ b/jd-wrapper.sh
@@ -2,13 +2,14 @@
 
 JDDIR=$XDG_DATA_HOME/jdownloader
 JDSETUP=$XDG_CACHE_HOME/JD2Setup.sh
+JDDWNLDFLDR="$(xdg-user-dir DOWNLOAD)/JDownloader"
 
 if [ ! -f $JDDIR/JDownloader.jar ]; then
     install -Dm755 /app/extra/JD2Setup.sh $JDSETUP
     $JDSETUP -q -dir $JDDIR/tmp | zenity --progress --text="Installing JDownloader" --pulsate --no-cancel --auto-close
     mv $JDDIR/tmp/JDownloader.jar $JDDIR
     rm -rf $JDSETUP $JDDIR/tmp
-    zenity --info --text "Download directory: $HOME/JDownloader" --no-wrap --title "JDownloader"
+    zenity --info --text "Download directory: ${JDDWNLDFLDR}" --no-wrap --title "JDownloader"
 fi
 
 java -jar $JDDIR/JDownloader.jar

--- a/org.jdownloader.JDownloader.yaml
+++ b/org.jdownloader.JDownloader.yaml
@@ -12,6 +12,7 @@ finish-args:
   - --socket=x11
   - --share=ipc
   - --filesystem=xdg-download/JDownloader:create
+  - --filesystem=~/JDownloader
   - --share=network
   - --env=PATH=/usr/bin:/app/bin:/app/jre/bin
   - --env=JAVA_HOME=/app/jre

--- a/org.jdownloader.JDownloader.yaml
+++ b/org.jdownloader.JDownloader.yaml
@@ -11,7 +11,7 @@ command: jd-wrapper
 finish-args:
   - --socket=x11
   - --share=ipc
-  - --filesystem=~/JDownloader:create
+  - --filesystem=xdg-download/JDownloader:create
   - --share=network
   - --env=PATH=/usr/bin:/app/bin:/app/jre/bin
   - --env=JAVA_HOME=/app/jre


### PR DESCRIPTION
...so users have all downloads where they belong to (Download folder) but still have a sandboxed folder for just JDownloader files.

Part of this report: https://github.com/flathub/org.jdownloader.JDownloader/issues/3