### PR TITLE
Update runtime and modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.flatpak-builder

--- a/org.jdownloader.JDownloader.yaml
+++ b/org.jdownloader.JDownloader.yaml
@@ -18,15 +18,6 @@ modules:
     buildsystem: simple
     build-commands: [/usr/lib/sdk/openjdk11/install.sh]
 
-  - name: unrar
-    no-autogen: true
-    make-install-args:
-      - DESTDIR=/app
-    sources:
-      - type: archive
-        url: https://www.rarlab.com/rar/unrarsrc-5.9.4.tar.gz
-        sha256: 3d010d14223e0c7a385ed740e8f046edcbe885e5c22c5ad5733d009596865300
-
   - name: ffmpeg
     config-opts:
       - --enable-rpath

--- a/org.jdownloader.JDownloader.yaml
+++ b/org.jdownloader.JDownloader.yaml
@@ -4,7 +4,7 @@ tags: [proprietary]
 runtime: org.freedesktop.Platform
 runtime-version: '20.08'
 sdk: org.freedesktop.Sdk
-sdk-extensions: [org.freedesktop.Sdk.Extension.openjdk11]
+sdk-extensions: [org.freedesktop.Sdk.Extension.openjdk17]
 command: jd-wrapper
 finish-args:
   - --socket=x11
@@ -16,7 +16,7 @@ finish-args:
 modules:
   - name: openjdk
     buildsystem: simple
-    build-commands: [/usr/lib/sdk/openjdk11/install.sh]
+    build-commands: [/usr/lib/sdk/openjdk17/install.sh]
 
   - name: ffmpeg
     config-opts:

--- a/org.jdownloader.JDownloader.yaml
+++ b/org.jdownloader.JDownloader.yaml
@@ -34,8 +34,8 @@ modules:
       - /share/ffmpeg/examples
     sources:
       - type: archive
-        url: https://www.ffmpeg.org/releases/ffmpeg-4.3.1.tar.xz
-        sha256: ad009240d46e307b4e03a213a0f49c11b650e445b1f8be0dda2a9212b34d2ffb
+        url: https://ffmpeg.org/releases/ffmpeg-4.4.2.tar.xz
+        sha256: af419a7f88adbc56c758ab19b4c708afbcae15ef09606b82b855291f6a6faa93
 
   - name: jdownloader
     buildsystem: simple

--- a/org.jdownloader.JDownloader.yaml
+++ b/org.jdownloader.JDownloader.yaml
@@ -2,7 +2,7 @@ app-id: org.jdownloader.JDownloader
 default-branch: stable
 tags: [proprietary]
 runtime: org.freedesktop.Platform
-runtime-version: '20.08'
+runtime-version: '21.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions: [org.freedesktop.Sdk.Extension.openjdk17]
 command: jd-wrapper


### PR DESCRIPTION
Hi,

unrar is not used anymore, jd has switched to 7zip
sticking to latest 4.x ffmpeg release as it didn't seemed to work with fresh ffmpeg 5.0.1 release

regards,
Nicolas