### PR TITLE
Fix: Update ffmpeg to use same ffmpeg-full as provided by runtime but include missing muxers required by jd (fixes #27)

### DIFF
--- a/org.jdownloader.JDownloader.yaml
+++ b/org.jdownloader.JDownloader.yaml
@@ -2,6 +2,7 @@ app-id: org.jdownloader.JDownloader
 default-branch: stable
 runtime: org.freedesktop.Platform
 runtime-version: "22.08"
+x-openh264-version: &openh264-version "2.3.1"
 sdk: org.freedesktop.Sdk
 command: jd-wrapper
 tags:
@@ -15,10 +16,21 @@ finish-args:
   - --filesystem=/media
   - --share=network
   - --env=PATH=/app/bin:/app/jre/bin:/usr/bin
+  - --env=LD_LIBRARY_PATH=/app/lib/ffmpeg:/app/lib/openh264/extra
   - --env=JAVA_HOME=/app/jre
 
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17
+
+add-extensions:
+  org.freedesktop.Platform.openh264:
+    directory: lib/openh264
+    add-ld-path: .
+    version: *openh264-version
+    autodelete: false
+
+cleanup-commands:
+  - mkdir -p /app/lib/openh264
 
 modules:
   - name: openjdk
@@ -26,24 +38,65 @@ modules:
     build-commands:
       - /usr/lib/sdk/openjdk17/install.sh
 
+  # TODO: Switch to ffmpeg-full extension once platform 23.08 is available as missing (de)muxers are now included in standard
+  # Configuration based on freedesktop-sdk-22.08.12.1 ffmpeg and ffmpeg-full with some simplifications from 23.08beta
   - name: ffmpeg
+    buildsystem: autotools
+    build-options:
+      prefix: /app/lib/ffmpeg
+      libdir: /app/lib/ffmpeg
+      cflags: -O2 -g -pipe -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches
+      ldflags: -Wl,-z,relro,-z,now -Wl,--as-needed
+      arch:
+        x86_64:
+          cflags: -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer
+        aarch64:
+          cflags: -fasynchronous-unwind-tables -fstack-clash-protection -fno-omit-frame-pointer
     config-opts:
-      - --enable-rpath
-      - --enable-gpl
+      - --disable-stripping
+      - --disable-doc
       - --disable-static
       - --enable-shared
-      - --disable-doc
-      - --disable-ffplay
-      - --disable-avdevice
-      - --disable-swresample
-      - --disable-swscale
-      - --disable-postproc
+      - --disable-programs
+      - --enable-gnutls
+      - --enable-libaom
+      - --enable-libdav1d
+      - --enable-libfdk-aac
+      - --enable-libmp3lame
+      - --enable-libfontconfig
+      - --enable-libfreetype
+      - --enable-libopus
+      - --enable-libpulse
+      - --enable-libspeex
+      - --enable-libtheora
+      - --enable-libvorbis
+      - --enable-libvpx
+      - --enable-libwebp
+      - --enable-openal
+      - --enable-opengl
+      - --enable-sdl2
+      - --enable-vulkan
+      - --enable-zlib
+      - --enable-libv4l2
+      - --enable-libxcb
+      - --enable-vdpau
+      - --enable-vaapi
+      - --enable-pthreads
+      - --enable-encoders
+      - --enable-encoders
+      - --enable-libopenh264
     cleanup:
-      - /share/ffmpeg/examples
+      - /lib/ffmpeg/include
+      - /lib/ffmpeg/pkgconfig
+      - /lib/ffmpeg/share
     sources:
-      - type: archive
-        url: https://ffmpeg.org/releases/ffmpeg-4.4.2.tar.xz
-        sha256: af419a7f88adbc56c758ab19b4c708afbcae15ef09606b82b855291f6a6faa93
+      - type: git
+        url: https://git.ffmpeg.org/ffmpeg.git
+        tag: n5.0.3
+        commit: 0e15444aceca0e78f99f3d67758eb79d11b86599
+        x-checker-data:
+          type: git
+          tag-pattern: ^n((?:\d+\.){1,2}\d+)$
 
   - name: jdownloader
     buildsystem: simple

--- a/org.jdownloader.JDownloader.yaml
+++ b/org.jdownloader.JDownloader.yaml
@@ -1,11 +1,12 @@
 app-id: org.jdownloader.JDownloader
 default-branch: stable
-tags: [proprietary]
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: "22.08"
 sdk: org.freedesktop.Sdk
-sdk-extensions: [org.freedesktop.Sdk.Extension.openjdk17]
 command: jd-wrapper
+tags:
+  - proprietary
+
 finish-args:
   - --socket=x11
   - --share=ipc
@@ -15,10 +16,15 @@ finish-args:
   - --share=network
   - --env=PATH=/app/bin:/app/jre/bin:/usr/bin
   - --env=JAVA_HOME=/app/jre
+
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.openjdk17
+
 modules:
   - name: openjdk
     buildsystem: simple
-    build-commands: [/usr/lib/sdk/openjdk17/install.sh]
+    build-commands:
+      - /usr/lib/sdk/openjdk17/install.sh
 
   - name: ffmpeg
     config-opts:

--- a/org.jdownloader.JDownloader.yaml
+++ b/org.jdownloader.JDownloader.yaml
@@ -105,6 +105,9 @@ modules:
       - install -Dm644 -t /app/share/metainfo org.jdownloader.JDownloader.metainfo.xml
       - install -Dm644 -t /app/share/applications org.jdownloader.JDownloader.desktop
       - install -Dm644 -t /app/share/icons/hicolor/512x512/apps org.jdownloader.JDownloader.png
+      # Allows backward compatibility
+      - ln -srv /usr/bin/ffmpeg /app/bin/ffmpeg
+      - ln -srv /usr/bin/ffprobe /app/bin/ffprobe
     sources:
       - type: file
         path: jd-wrapper.sh


### PR DESCRIPTION
This is temporary. We will be able to switch completely to ffmpeg-full once platform 23.08 is available