### PR TITLE
Switch to JDownloader.jar download and update architecture support (Fixes #51)

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-  "only-arches": ["x86_64"]
+  "only-arches": ["x86_64", "i386", "aarch64", "riscv64"]
 }

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-  "only-arches": ["x86_64", "i386", "aarch64", "riscv64"]
-}

--- a/jd-wrapper.sh
+++ b/jd-wrapper.sh
@@ -3,8 +3,7 @@
 JDDIR=${XDG_DATA_HOME}/jdownloader
 
 if ! jar -tvf ${JDDIR}/JDownloader.jar > /dev/null 2>&1; then
-    rm -f ${JDDIR}/Core.jar
-    rm -rf ${JDDIR}/update ${JDDIR}/tmp
+    rm -rf ${JDDIR}/JDownloader.jar ${JDDIR}/Core.jar ${JDDIR}/update ${JDDIR}/tmp 2>/dev/null
     mkdir -p ${JDDIR}
     cp /app/extra/JDownloader.jar ${JDDIR}/
 fi

--- a/jd-wrapper.sh
+++ b/jd-wrapper.sh
@@ -2,7 +2,7 @@
 
 JDDIR=${XDG_DATA_HOME}/jdownloader
 
-if [ ! -f ${JDDIR}/JDownloader.jar ] || ! jar -tvf ${JDDIR}/JDownloader.jar > /dev/null 2>&1; then
+if ! jar -tvf ${JDDIR}/JDownloader.jar > /dev/null 2>&1; then
     rm -f ${JDDIR}/Core.jar
     rm -rf ${JDDIR}/update ${JDDIR}/tmp
     mkdir -p ${JDDIR}

--- a/jd-wrapper.sh
+++ b/jd-wrapper.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 
 JDDIR=${XDG_DATA_HOME}/jdownloader
-JDSETUP=${XDG_CACHE_HOME}/JD2Setup.sh
 
 if [ ! -f ${JDDIR}/JDownloader.jar ]; then
-    install -Dm755 /app/extra/JD2Setup.sh ${JDSETUP}
-    ${JDSETUP} -q -dir ${JDDIR}/tmp | zenity --progress --text="Installing JDownloader" --pulsate --no-cancel --auto-close
-    mv ${JDDIR}/tmp/JDownloader.jar ${JDDIR}
-    rm -rf ${JDSETUP} ${JDDIR}/tmp
+    mkdir -p ${JDDIR}
+    cp /app/extra/JDownloader.jar ${JDDIR}/
 fi
 
 exec java -jar ${JDDIR}/JDownloader.jar "${@}"

--- a/jd-wrapper.sh
+++ b/jd-wrapper.sh
@@ -2,7 +2,9 @@
 
 JDDIR=${XDG_DATA_HOME}/jdownloader
 
-if [ ! -f ${JDDIR}/JDownloader.jar ]; then
+if [ ! -f ${JDDIR}/JDownloader.jar ] || ! jar -tvf ${JDDIR}/JDownloader.jar > /dev/null 2>&1; then
+    rm -f ${JDDIR}/Core.jar
+    rm -rf ${JDDIR}/update ${JDDIR}/tmp
     mkdir -p ${JDDIR}
     cp /app/extra/JDownloader.jar ${JDDIR}/
 fi

--- a/jd-wrapper.sh
+++ b/jd-wrapper.sh
@@ -5,7 +5,7 @@ JDDIR=${XDG_DATA_HOME}/jdownloader
 if ! jar -tvf ${JDDIR}/JDownloader.jar > /dev/null 2>&1; then
     rm -rf ${JDDIR}/JDownloader.jar ${JDDIR}/Core.jar ${JDDIR}/update ${JDDIR}/tmp 2>/dev/null
     mkdir -p ${JDDIR}
-    cp /app/extra/JDownloader.jar ${JDDIR}/
+    install -Dm644 /app/extra/JDownloader.jar ${JDDIR}
 fi
 
 exec java -jar ${JDDIR}/JDownloader.jar "${@}"

--- a/org.jdownloader.JDownloader.yaml
+++ b/org.jdownloader.JDownloader.yaml
@@ -60,7 +60,7 @@ modules:
       - type: file
         path: org.jdownloader.JDownloader.metainfo.xml
       - type: extra-data
-        filename: JD2Setup.sh
-        url: https://installer.jdownloader.org/JD2Setup_x64.sh
-        sha256: ddd1a997afaf60c981fbfb1a1f3a600ff7bad7fccece9f2508fb695b8c2f153d
-        size: 50621986
+        filename: JDownloader.jar
+        url: https://installer.jdownloader.org/flatpak/2025-11-04/JDownloader.jar
+        sha256: 388a1d028e65cbc63933a778ddbc9267c14e7e7858389ce31a10be7308adeb40
+        size: 5189769


### PR DESCRIPTION
Closes #51.

As reported in the issue, the JDownloader team has disabled the outdated `JD2Setup_x64.sh` installer script. They have provided a new static URL to fetch the `JDownloader.jar` file directly, which is all this flatpak needs.

This PR implements their requested changes:

- Removes the old `JD2Setup_x64.sh` source and the build steps required to run it.
- Adds the new static URL for `JDownloader.jar` as a primary source with the correct file size and sha256 hash
- Updates architecture support: Since we are now using the architecture-independent `.jar` file instead of an `x86_64`-specific shell script, this commit also updates the supported architectures (e.g., adding `aarch64`).

This should fix the build failures and simplifies the overall manifest.